### PR TITLE
Fix node attributes assignment

### DIFF
--- a/rotate_logs/attributes/default.rb
+++ b/rotate_logs/attributes/default.rb
@@ -4,10 +4,10 @@ end
 
 node.override['logrotate']['global']['weekly'] = true
 
-node['logrotate']['global']['rotate'] = 4
+node.default['logrotate']['global']['rotate'] = 4
 
-node['logrotate']['global']['create'] = true
+node.default['logrotate']['global']['create'] = true
 
-node['logrotate']['global']['dateext'] = true
+node.default['logrotate']['global']['dateext'] = true
 
-node['logrotate']['global']['include'] = '/etc/logrotate.d'
+node.default['logrotate']['global']['include'] = '/etc/logrotate.d'

--- a/rotate_logs/recipes/default.rb
+++ b/rotate_logs/recipes/default.rb
@@ -1,14 +1,14 @@
 include_recipe 'logrotate::global'
 include_recipe 'logrotate::default'
 
-node['logrotate']['global']['/var/log/wtmp'] = {
+node.set['logrotate']['global']['/var/log/wtmp'] = {
   'monthly' => true,
   'create'  => '0664 root utmp',
   'rotate'  => 1,
   'minsize' => '1M'
 }
 
-node['logrotate']['global']['/var/log/btmp'] = {
+node.set['logrotate']['global']['/var/log/btmp'] = {
   'missingok' => true,
   'monthly'   => true,
   'create'    => '0600 root utmp',


### PR DESCRIPTION
We need to explicitly mention precedence level when writing now.

The way we were setting the attributes was removed in chef 11 when the API was made stricter.

More details here: https://blog.chef.io/2013/02/05/chef-11-in-depth-attributes-changes/