### PR TITLE
Copy logs to S3 after rotation

### DIFF
--- a/rotate_logs/recipes/default.rb
+++ b/rotate_logs/recipes/default.rb
@@ -35,7 +35,7 @@ logrotate_app 'nginx' do
   path       '/var/log/nginx/*log'
   options    ['missingok', 'notifempty', 'compress', 'sharedscripts']
   frequency  'daily'
-  rotate     10
+  rotate     5
   create     '0644 nginx nginx'
   postrotate <<-EOF
     /etc/init.d/nginx reopen_logs
@@ -82,7 +82,7 @@ node['logrotate']['rails_apps'].each do |app_name, app_data|
     path       app_data['log_path']
     options    ['missingok', 'compress', 'delaycompress', 'notifempty', 'copytruncate', 'sharedscripts']
     frequency  'daily'
-    rotate     30
+    rotate     5
     postrotate <<-EOF
       export AWS_ACCESS_KEY_ID=#{node['logrotate']['aws_access_key']}
       export AWS_SECRET_ACCESS_KEY=#{node['logrotate']['aws_secret_key']}

--- a/rotate_logs/recipes/default.rb
+++ b/rotate_logs/recipes/default.rb
@@ -37,7 +37,14 @@ logrotate_app 'nginx' do
   frequency  'daily'
   rotate     10
   create     '0644 nginx nginx'
-  postrotate ['/etc/init.d/nginx reopen_logs']
+  postrotate <<-EOF
+    /etc/init.d/nginx reopen_logs
+
+    export AWS_ACCESS_KEY_ID=#{node['logrotate']['aws_access_key']}
+    export AWS_SECRET_ACCESS_KEY=#{node['logrotate']['aws_secret_key']}
+
+    /usr/bin/aws s3 cp #{node['logrotate']['nginx']['log_dir']} s3://#{node['logrotate']['s3_bucket']}/'$HOMENAME'/#{node['logrotate']['nginx']['s3_dir']}/ --region #{node['logrotate']['s3_region']} #{node['logrotate']['nginx']['options']}
+  EOF
 end
 
 logrotate_app 'psacct' do


### PR DESCRIPTION
On `postrotate`, copy rails and nginx logs to s3 logs bucket
They will be removed from machines after 5 days now instead of 30 and 10 days respectively.

Part of https://www.pivotaltracker.com/story/show/148065025