### PR TITLE
Fix hostname folder name for logs

### DIFF
--- a/rotate_logs/recipes/default.rb
+++ b/rotate_logs/recipes/default.rb
@@ -48,7 +48,7 @@ logrotate_app 'nginx' do
     export AWS_ACCESS_KEY_ID=#{node['logrotate']['aws_access_key']}
     export AWS_SECRET_ACCESS_KEY=#{node['logrotate']['aws_secret_key']}
 
-    /usr/bin/aws s3 cp #{node['logrotate']['nginx']['log_dir']} s3://#{node['logrotate']['s3_bucket']}/'$HOSTNAME'/#{node['logrotate']['nginx']['s3_dir']}/ --region #{node['logrotate']['s3_region']} #{node['logrotate']['nginx']['options']}
+    /usr/bin/aws s3 cp #{node['logrotate']['nginx']['log_dir']} s3://#{node['logrotate']['s3_bucket']}/$HOSTNAME/#{node['logrotate']['nginx']['s3_dir']}/ --region #{node['logrotate']['s3_region']} #{node['logrotate']['nginx']['options']}
   EOF
 end
 
@@ -96,7 +96,7 @@ node['logrotate']['rails_apps'].each do |app_name, app_data|
       export AWS_ACCESS_KEY_ID=#{node['logrotate']['aws_access_key']}
       export AWS_SECRET_ACCESS_KEY=#{node['logrotate']['aws_secret_key']}
 
-      /usr/bin/aws s3 cp #{app_data['log_dir']} s3://#{node['logrotate']['s3_bucket']}/'$HOSTNAME'/#{app_data['s3_dir']}/ --region #{node['logrotate']['s3_region']} #{app_data['options']}
+      /usr/bin/aws s3 cp #{app_data['log_dir']} s3://#{node['logrotate']['s3_bucket']}/$HOSTNAME/#{app_data['s3_dir']}/ --region #{node['logrotate']['s3_region']} #{app_data['options']}
     EOF
   end
 end


### PR DESCRIPTION
We don't need to wrap it in string actually to get actual hostname in that path.
If we wrap it in string, it just uses that as it is.