### PR TITLE
Add newrelic infrastructure cookbook

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "logrotate"]
 	path = logrotate
 	url = https://github.com/stevendanna/logrotate
+[submodule "infrastructure-agent-chef"]
+	path = infrastructure-agent-chef
+	url = https://github.com/newrelic/infrastructure-agent-chef


### PR DESCRIPTION
Add the cookbook as submodule.
Will be needed in https://www.pivotaltracker.com/story/show/147829341

We can add newrelic infrastructure directly from command line in ec2
instances but that's not scalable as we will have to do that for each
new instance.