### PR TITLE
Add ruby 2.3.7 support

### DIFF
--- a/ruby/attributes/customize.rb
+++ b/ruby/attributes/customize.rb
@@ -1,0 +1,12 @@
+case node['opsworks']['ruby_version']
+when '2.3'
+  normal[:ruby][:major_version] = '2'
+  normal[:ruby][:minor_version] = '3'
+  normal[:ruby][:patch_version] = '7'
+  normal[:ruby][:pkgrelease]    = '1'
+
+  normal[:ruby][:full_version] = [node[:ruby][:major_version],
+                                  node[:ruby][:minor_version]].join('.')
+  normal[:ruby][:version] = [node[:ruby][:full_version],
+                             node[:ruby][:patch_version]].join('.')
+end


### PR DESCRIPTION
Add ruby 2.3.7 support by overriding default attributes according to this manual https://docs.aws.amazon.com/opsworks/latest/userguide/cookbooks-101-opsworks-attributes.html

also see comment at the top of this file: 
https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.10/ruby/attributes/ruby.rb