### PR TITLE
Upgrade to 2.3.8

### DIFF
--- a/ruby/attributes/customize.rb
+++ b/ruby/attributes/customize.rb
@@ -2,7 +2,7 @@ case node['opsworks']['ruby_version']
 when '2.3'
   normal[:ruby][:major_version] = '2'
   normal[:ruby][:minor_version] = '3'
-  normal[:ruby][:patch_version] = '7'
+  normal[:ruby][:patch_version] = '8'
   normal[:ruby][:pkgrelease]    = '1'
 
   normal[:ruby][:full_version] = [node[:ruby][:major_version],


### PR DESCRIPTION
Upgrade ruby version to 2.3.8. Availability of 2.3.8 on AWS is not clear, since it does not show patch version. But for staging we can specify github branch, in which chef recipe is located, so we can test it on staging even before merge. 