### PR TITLE
Avoid crash at startup because of closed connection

### DIFF
--- a/unicorn/templates/default/unicorn.conf.erb
+++ b/unicorn/templates/default/unicorn.conf.erb
@@ -44,8 +44,10 @@ before_fork do |server, worker|
     I18n.t('foobar')
 
     # Warm models, load schema
-    (ActiveRecord::Base.connection.tables - %w[schema_migrations]).each do |table|
-      table.classify.constantize.first rescue nil
+    if ActiveRecord::Base.connection.active?
+      (ActiveRecord::Base.connection.tables - %w[schema_migrations]).each do |table|
+        table.classify.constantize.first rescue nil
+      end
     end
 
     # Warm the router


### PR DESCRIPTION
Currently sending SIGHUP to master unicorn process makes it crash instead of graceful restart:
```
I, [2019-04-12T08:44:50.812848 #26176]  INFO -- : reloading config_file=/srv/www/jiffyshirts/shared/config/unicorn.conf
I, [2019-04-12T08:44:50.892036 #26176]  INFO -- : Refreshing Gem list
I, [2019-04-12T08:44:50.992122 #26176]  INFO -- : done reloading config_file=/srv/www/jiffyshirts/shared/config/unicorn.conf
I, [2019-04-12T08:44:51.181301 #26176]  INFO -- : reaped #<Process::Status: pid 26242 exit 0> worker=1
E, [2019-04-12T08:44:51.182093 #26176] ERROR -- : PG::ConnectionBad: connection is closed: SELECT tablename FROM pg_tables WHERE schemaname = ANY(current_schemas(false)) (ActiveRecord::StatementInvalid)
/home/deploy/.bundler/jiffyshirts/ruby/2.3.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/postgresql_adapter.rb:600:in `async_exec'
/home/deploy/.bundler/jiffyshirts/ruby/2.3.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/postgresql_adapter.rb:600:in `block in exec_no_cache'
/home/deploy/.bundler/jiffyshirts/ruby/2.3.0/gems/activerecord-5.0.7.2/lib/active_record/connection_adapters/abstract_adapter.rb:590:in `block in log'
```
(log from kamino)

I suggest adding the connection check before warming up. If fixes problem for me.