### PR TITLE
Add proxy_buffer_size directive

### DIFF
--- a/nginx/templates/default/nginx.conf.erb
+++ b/nginx/templates/default/nginx.conf.erb
@@ -37,6 +37,10 @@ http {
 
   client_max_body_size <%= node[:nginx][:client_max_body_size] %>;
 
+  <% if node[:nginx][:proxy_buffer_size] %>
+  proxy_buffer_size <%= node[:nginx][:proxy_buffer_size] %>;
+  <% end %>
+
   server_names_hash_bucket_size <%= node[:nginx][:server_names_hash_bucket_size] %>;
 
   include <%= node[:nginx][:dir] %>/conf.d/*.conf;


### PR DESCRIPTION
Researching problem with ApplePay I found this in staging logs:
```
2019/04/23 11:03:21 [error] 19383#0: *1603419 upstream sent too big header while reading response header from upstream, client: 10.0.4.84, server: jiffyshirts, request: "GET /checkout/device-pay/cancelled HTTP/1.1", upstream: "http://unix:/srv/www/jiffyshirts/shared/sockets/unicorn.sock:/checkout/device-pay/cancelled", host: "bespin.sdtechdev.com", referrer: "https://bespin.sdtechdev.com/cart/buy"
```

Further research showed that problem was caused by storing large hash with addresses and card data in app session.
Normally we use ~2kb of headers with limit of ~4kb. 

I suggest to increase buffer size to 8kb so we'll have x3 capacity instead of x2.