### PR TITLE
Add json2parquet and docopt installation

### DIFF
--- a/python-deps/metadata.rb
+++ b/python-deps/metadata.rb
@@ -1,0 +1,6 @@
+name             'python_deps'
+maintainer       'SDTechDev Dev Team'
+maintainer_email 'dev@sdtechdev.com'
+license          'Proprietary - All Rights Reserved'
+description      'installs jiffyshirts app python deps'
+version          '0.1.0'

--- a/python-deps/recipes/default.rb
+++ b/python-deps/recipes/default.rb
@@ -1,0 +1,13 @@
+bash 'install-pip' do
+  user 'root'
+  cwd '/tmp'
+  code <<-EOH
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    python get-pip.py
+  EOH
+end
+
+bash 'install-python-deps' do
+  user 'root'
+  code 'pip install docopt json2parquet'
+end


### PR DESCRIPTION
install dependencies needed for this https://github.com/sdtechdev/spree-jiffyshirts/blob/728ed95fa5dc04b7b4f6fc30787cdb5cacae088e/bin/compress_parquet file,

This script is actually only way to easily convert logs table to compressed `.parquet` file, gems for ruby don't support compression and need soo many deps from glib whatever