### PR TITLE
Add rust recipes

### DIFF
--- a/rust/metadata.rb
+++ b/rust/metadata.rb
@@ -1,0 +1,6 @@
+name             'rust'
+maintainer       'SDTechDev Dev Team'
+maintainer_email 'dev@sdtechdev.com'
+license          'Proprietary - All Rights Reserved'
+description      'installs rust for jiffyshirts app'
+version          '0.1.0'

--- a/rust/recipes/compile.rb
+++ b/rust/recipes/compile.rb
@@ -1,0 +1,12 @@
+node[:deploy].each do |application, deploy|
+  deploy = node[:deploy][application]
+
+  bash "compile-rust-#{application}" do
+    user deploy[:user]
+    group 'nginx'
+    environment 'HOME' => '/home/deploy'
+
+    cwd "#{deploy[:deploy_to]}/current/crates/assignment"
+    code '~/.cargo/bin/cargo build --release'
+  end
+end

--- a/rust/recipes/install.rb
+++ b/rust/recipes/install.rb
@@ -1,0 +1,6 @@
+bash 'install-rust' do
+  user 'deploy'
+  environment 'HOME' => '/home/deploy'
+  cwd '/home/deploy'
+  code 'curl https://sh.rustup.rs -sSf | sh -s -- -y'
+end


### PR DESCRIPTION
This PR adds two recipes:
* install - will be running on setup
* compile - will be running on deploy

We need this to be able to compile rust code on Staging/Production environments.