### PR TITLE
Install AWS CloudWatch Agent

### DIFF
--- a/cloudwatch-agent/files/default/amazon-cloudwatch-agent.json
+++ b/cloudwatch-agent/files/default/amazon-cloudwatch-agent.json
@@ -1,0 +1,8 @@
+{
+  "metrics": {
+    "namespace": "StatsD",
+    "metrics_collected": {
+      "statsd": {}
+    }
+  }
+}

--- a/cloudwatch-agent/metadata.rb
+++ b/cloudwatch-agent/metadata.rb
@@ -1,0 +1,6 @@
+name             'cloudwatch-agent'
+maintainer       'SDTechDev Dev Team'
+maintainer_email 'dev@sdtechdev.com'
+license          'Proprietary - All Rights Reserved'
+description      'installs cloudwatch agent for custom statsd monitoring'
+version          '0.0.1'

--- a/cloudwatch-agent/recipes/install.rb
+++ b/cloudwatch-agent/recipes/install.rb
@@ -1,0 +1,20 @@
+remote_file '/opt/amazon-cloudwatch-agent.rpm' do
+  source 'https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm'
+end
+
+rpm_package 'amazon-cloudwatch-agent.rpm' do
+  source '/opt/amazon-cloudwatch-agent.rpm'
+  action :install
+end
+
+cookbook_file '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent-statsd.json' do
+  source 'amazon-cloudwatch-agent.json'
+end
+
+bash 'run agent' do
+  code 'amazon-cloudwatch-agent-ctl -a start -m ec2'
+end
+
+bash 'configure agent' do
+  code "amazon-cloudwatch-agent-ctl -a fetch-config -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent-statsd.json"
+end


### PR DESCRIPTION
Download, install and apply default config to collect metrics from
statsd. Having `statsd` config option would also make agent to run a
statsd daemon listening on 8125 port.