### PR TITLE
Stop distinct statsd metrics by hostname

### DIFF
--- a/cloudwatch-agent/files/default/amazon-cloudwatch-agent.json
+++ b/cloudwatch-agent/files/default/amazon-cloudwatch-agent.json
@@ -1,4 +1,7 @@
 {
+  "agent": {
+    "omit_hostname": true
+  },
   "metrics": {
     "namespace": "StatsD",
     "metrics_collected": {

--- a/cloudwatch-agent/recipes/configure.rb
+++ b/cloudwatch-agent/recipes/configure.rb
@@ -1,0 +1,7 @@
+cookbook_file '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent-statsd.json' do
+  source 'amazon-cloudwatch-agent.json'
+end
+
+bash 'configure agent' do
+  code "amazon-cloudwatch-agent-ctl -a fetch-config -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent-statsd.json"
+end


### PR DESCRIPTION
We don't have to distinct metrics by hostname. Omitting hostname in
agent config allows to aggregate metrics by name, not by hostname.