### PR TITLE
Install cloudwatch agent only if it's not yet installed

### DIFF
--- a/cloudwatch-agent/recipes/install.rb
+++ b/cloudwatch-agent/recipes/install.rb
@@ -1,10 +1,10 @@
 remote_file '/opt/amazon-cloudwatch-agent.rpm' do
   source 'https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm'
+  action :create_if_missing
 end
 
 rpm_package 'amazon-cloudwatch-agent.rpm' do
   source '/opt/amazon-cloudwatch-agent.rpm'
-  action :install
 end
 
 cookbook_file '/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent-statsd.json' do


### PR DESCRIPTION
Currently we're facing an issue when distributed CloudWatch Agent has lower version than we have already installed. It happens only for already setuped and stoped instances (like time or load based) because RPM does not allow to install downgraded packages by default. 