### PR TITLE
Support sidekiq 6

### DIFF
--- a/opsworks_sidekiq/recipes/configure.rb
+++ b/opsworks_sidekiq/recipes/configure.rb
@@ -9,12 +9,6 @@ node[:deploy].each do |application, deploy|
     next
   end
 
-  execute "restart Sidekiq app #{application}" do
-    cwd deploy[:current_path]
-    command node[:sidekiq][application][:restart_command]
-    action :nothing
-  end
-
   node.default[:deploy][application][:database][:adapter] = OpsWorks::RailsConfiguration.determine_database_adapter(application, node[:deploy][application], "#{node[:deploy][application][:deploy_to]}/current", force: node[:force_database_adapter_detection])
   deploy = node[:deploy][application]
 
@@ -47,7 +41,7 @@ node[:deploy].each do |application, deploy|
       environment: deploy[:rails_env]
     )
 
-    notifies :run, "execute[restart Rails app #{application}]"
+    notifies :run, "execute[restart Sidekiq app #{application}]"
 
     only_if do
       deploy[:memcached][:host].present? && File.directory?("#{deploy[:deploy_to]}/shared/config/")

--- a/opsworks_sidekiq/recipes/service.rb
+++ b/opsworks_sidekiq/recipes/service.rb
@@ -12,8 +12,8 @@ node[:deploy].each do |application, deploy|
 
   # Overwrite the unicorn restart command declared elsewhere
   # Apologies for the `sleep`, but monit errors with "Other action already in progress" on some boots.
-  execute "restart Rails app #{application}" do
-    command "sleep 60 && #{node[:sidekiq][application][:restart_command]}"
+  execute "restart Sidekiq app #{application}" do
+    command "sleep 150 && #{node[:sidekiq][application][:restart_command]}"
     action :nothing
   end
 

--- a/opsworks_sidekiq/templates/default/sidekiq_monitrc.erb
+++ b/opsworks_sidekiq/templates/default/sidekiq_monitrc.erb
@@ -1,18 +1,20 @@
 <% @workers.each do |worker, options| %>
-  <% (options[:process_count] || 1).times do |n| %>
-  <% identifier = "#{@application}-#{worker}#{n+1}" %>
-  <% conf_file = "#{@deploy[:deploy_to]}/shared/config/sidekiq_#{worker}#{n+1}.yml" %>
-  <% pid_file = "#{@deploy[:deploy_to]}/shared/pids/sidekiq_#{identifier}.pid" %>
-  <% if @syslog %>
-    <% ident = @syslog_ident ? @syslog_ident : "sidekiq-#{identifier}" %>
-    <% syslog = "2>&1 | logger -t #{ident}" %>
+  <% sidekiq_process_count = options[:process_count] || 1 %>
+  <% identifier = "#{@application}-#{worker}" %>
+  <% memory_limit_mb = options[:memory_limit_mb] || 2048 %>
+  <% sidekiq_timeout = options[:sidekiq_timeout] || 10 %>
+  <% conf_file = "#{@deploy[:deploy_to]}/shared/config/sidekiq_#{worker}.yml" %>
+  <% log_file = options[:config][:logfile] %>
+  <% ident = @opts[:syslog_ident] ? @opts[:syslog_ident] : "sidekiq-#{identifier}" %>
+  <% logger = '' %>
+  <% if log_file %>
+    <% logger = "2>&1 >> #{log_file}" %>
+  <% elsif !!@opts[:syslog] %>
+    <% logger = "2>&1 | logger -t #{ident}" %>
   <% end %>
 
-check process sidekiq_<%= identifier %>
-  with pidfile <%= pid_file %>
-  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> bundle exec sidekiq -C <%= conf_file %> -P  <%= pid_file %> <%= syslog %>'" with timeout 90 seconds
-  stop  program = "/bin/su - <%= @deploy[:user] %> -c 'kill -s TERM `cat <%= pid_file %>`'" with timeout 90 seconds
+check process sidekiq_<%= identifier %> matching "bundle exec sidekiq.*/sidekiq_<%= worker %>.yml"
+  start program = "/bin/su - <%= @deploy[:user] %> -c 'cd <%= @deploy[:current_path] %> && RAILS_ENV=<%= @deploy[:rails_env] %> SIDEKIQ_PRELOAD= SIDEKIQ_MAXMEM_MB=<%= memory_limit_mb %> SIDEKIQ_COUNT=<%= sidekiq_process_count %> bundle exec sidekiqswarm -C <%= conf_file %> -t <%= sidekiq_timeout %> -r <%= @deploy[:current_path] %> <%= logger %>'" with timeout 90 seconds
+  stop program = "/bin/su - <%= @deploy[:user] %> -c 'ps ax | grep sidekiq_<%= worker %>.yml | grep -v grep | awk "{printf \"%s%s\",sep,\$1; sep=\",\"} END{print \"\"}" | xargs -r pgrep -P | xargs -r kill'" with timeout 90 seconds
   group sidekiq_<%= @application %>_group
-
-  <% end %>
 <% end %>

--- a/opsworks_sidekiq/templates/default/sidekiq_monitrc.erb
+++ b/opsworks_sidekiq/templates/default/sidekiq_monitrc.erb
@@ -2,7 +2,7 @@
   <% sidekiq_process_count = options[:process_count] || 1 %>
   <% identifier = "#{@application}-#{worker}" %>
   <% memory_limit_mb = options[:memory_limit_mb] || 2048 %>
-  <% sidekiq_timeout = options[:sidekiq_timeout] || 10 %>
+  <% sidekiq_timeout = options[:sidekiq_timeout] || 30 %>
   <% conf_file = "#{@deploy[:deploy_to]}/shared/config/sidekiq_#{worker}.yml" %>
   <% log_file = options[:config][:logfile] %>
   <% ident = @opts[:syslog_ident] ? @opts[:syslog_ident] : "sidekiq-#{identifier}" %>


### PR DESCRIPTION
`sidekiq6` has some breaking changes with `process/worker` management/configuration. for the changes, we are using `monit` with process name matching rather than PID file. `sidekiq-swarm` has several advantages https://sorentwo.com/2016/06/28/effectively-scaling-sidekiq-workers.html.

tested setup/configuration/deployment on `bespin`