### PR TITLE
Do not restart Sidekiq on configure

### DIFF
--- a/opsworks_sidekiq/recipes/configure.rb
+++ b/opsworks_sidekiq/recipes/configure.rb
@@ -23,8 +23,6 @@ node[:deploy].each do |application, deploy|
       environment: deploy[:rails_env]
     )
 
-    notifies :run, "execute[restart Sidekiq app #{application}]"
-
     only_if do
       deploy[:database][:host].present? && File.directory?("#{deploy[:deploy_to]}/shared/config/")
     end
@@ -40,8 +38,6 @@ node[:deploy].each do |application, deploy|
       memcached: deploy[:memcached] || {},
       environment: deploy[:rails_env]
     )
-
-    notifies :run, "execute[restart Sidekiq app #{application}]"
 
     only_if do
       deploy[:memcached][:host].present? && File.directory?("#{deploy[:deploy_to]}/shared/config/")

--- a/opsworks_sidekiq/recipes/deploy.rb
+++ b/opsworks_sidekiq/recipes/deploy.rb
@@ -35,7 +35,7 @@ node[:deploy].each do |application, deploy|
   end
 
   Chef::Log.debug("Restarting Sidekiq Application: #{application}")
-  execute "restart Rails app #{application}" do
+  execute "restart Sidekiq app #{application}" do
     command node[:sidekiq][application][:restart_command]
   end
 


### PR DESCRIPTION
https://dekeo.atlassian.net/browse/BRAVO-3017

According to the next docs - https://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook-events.html
it's not required to restart Sidekiq processes on `configure` OpsWorks stack life-cycle event.

I've tested this PR on `scarif` and it's:
- not restarting on `configure` event processing triggered by `scarif-rails1` going online/offline
- restarting on `deploy` event processing, when redeploying from OpsWorks (repeat last deploy)
- restarting with `$ deploy scarif`