### PR TITLE
Add logging to unicorn restart script

### DIFF
--- a/unicorn/templates/default/unicorn.service.erb
+++ b/unicorn/templates/default/unicorn.service.erb
@@ -1,0 +1,109 @@
+#!/usr/local/bin/ruby
+
+require 'etc'
+require 'digest/md5'
+
+ROOT_PATH="<%= @deploy[:deploy_to] %>"
+APP_NAME="<%= @application %>"
+PID_PATH="<%= @deploy[:deploy_to] %>/shared/pids/unicorn.pid"
+
+def run_and_print_command(command)
+  puts command
+  system(command) || exit(1)
+end
+
+def run_and_ignore_exitcode_and_print_command(command)
+  puts command
+  system(command)
+end
+
+def unicorn_running?
+  if File.exists?(PID_PATH) && (pid = File.read(PID_PATH).chomp) && system("ps aux | grep #{pid} | grep -v grep > /dev/null")
+    pid
+  else
+    false
+  end
+end
+
+def different_gemfile?
+  if File.exists?("#{ROOT_PATH}/current/Gemfile")
+    dir = Dir["#{ROOT_PATH}/releases/*"]
+    previous_release_path = dir.sort[dir.size-2]
+    if !previous_release_path.nil? && File.exists?("#{previous_release_path}/Gemfile")
+      return Digest::MD5.hexdigest(File.read("#{ROOT_PATH}/current/Gemfile")) != Digest::MD5.hexdigest(File.read("#{previous_release_path}/Gemfile"))
+    end
+  end
+  false
+end
+
+def start_unicorn
+  if File.exists?("#{ROOT_PATH}/current/Gemfile")
+    puts "OpsWorks: Gemfile detected - running Unicorn with bundle exec"
+    run_and_ignore_exitcode_and_print_command "cd #{ROOT_PATH}/current && /usr/local/bin/bundle exec unicorn_rails --env <%= @deploy[:rails_env] %> --daemonize -c #{ROOT_PATH}/shared/config/unicorn.conf"
+  else
+    puts "OpsWorks: no Gemfile detected - running plain Unicorn"
+    run_and_ignore_exitcode_and_print_command "cd #{ROOT_PATH}/current && unicorn_rails --env <%= @deploy[:rails_env] %> --daemonize -c #{ROOT_PATH}/shared/config/unicorn.conf"
+  end
+end
+
+def stop_unicorn
+  if unicorn_running?
+    if run_and_ignore_exitcode_and_print_command "kill -QUIT `cat #{PID_PATH}`"
+      `rm #{PID_PATH}`
+    end
+  else
+    puts "You can't stop unicorn, because it's not running"
+  end
+end
+
+def restart_unicorn
+	if unicorn_running?
+		run_and_ignore_exitcode_and_print_command "kill -USR2 `cat #{PID_PATH}`"
+	else
+		start_unicorn
+	end
+end
+
+def clean_restart
+  if different_gemfile?
+    puts "Found a previous version with a different Gemfile: Doing a stop & start"
+    stop_unicorn if unicorn_running?
+    start_unicorn
+  else
+    puts "No previous version with a different Gemfile found. Assuming a quick restart without re-loading gems is save"
+    restart_unicorn
+  end
+end
+
+def status_unicorn
+	if pid = unicorn_running?
+		puts "Unicorn <%= @application %> running with PID #{pid}"
+		return true
+	else
+		puts "Unicorn <%= @application %> not running"
+		return false
+  end
+end
+
+Process::Sys.setuid(uid = Etc.getpwnam("<%= @deploy[:user] %>").uid)
+puts "Set Unicorn process UID to #{uid}"
+
+case ARGV[0]
+when "start"
+  puts "Starting Unicorn #{APP_NAME}"
+  start_unicorn
+when "stop"
+  puts "Stopping Unicorn #{APP_NAME}"
+  stop_unicorn
+when "status"
+  status_unicorn
+when "restart"
+  restart_unicorn
+when "clean-restart"
+  clean_restart
+else
+  puts "Usage: {start|stop|status|restart|clean-restart}"
+  exit 1
+end
+
+exit 0

--- a/unicorn/templates/default/unicorn.service.erb
+++ b/unicorn/templates/default/unicorn.service.erb
@@ -79,11 +79,11 @@ def stop_unicorn
 end
 
 def restart_unicorn
-	if unicorn_running?
-		run_and_ignore_exitcode_and_print_command "kill -USR2 `cat #{PID_PATH}`"
-	else
-		start_unicorn
-	end
+  if unicorn_running?
+    run_and_ignore_exitcode_and_print_command "kill -USR2 `cat #{PID_PATH}`"
+  else
+    start_unicorn
+  end
 end
 
 def clean_restart
@@ -98,12 +98,12 @@ def clean_restart
 end
 
 def status_unicorn
-	if pid = unicorn_running?
-		log "Unicorn <%= @application %> running with PID #{pid}"
-		true
-	else
-		log "Unicorn <%= @application %> not running"
-		false
+  if pid = unicorn_running?
+    log "Unicorn <%= @application %> running with PID #{pid}"
+    true
+  else
+    log "Unicorn <%= @application %> not running"
+    false
   end
 end
 

--- a/unicorn/templates/default/unicorn.service.erb
+++ b/unicorn/templates/default/unicorn.service.erb
@@ -16,7 +16,6 @@ LOG_PATH="<%= @deploy[:deploy_to] %>/shared/log/unicorn.restart.log"
 
 def run_and_print_command(command)
   log command
-  result = system(command)
   _stdout, stderr, status = Open3.capture3(command)
 
   if status.success?
@@ -40,8 +39,10 @@ end
 
 def unicorn_running?
   if File.exists?(PID_PATH) && (pid = File.read(PID_PATH).chomp) && system("ps aux | grep #{pid} | grep -v grep > /dev/null")
+    log "Performed running check: unicorn is running with PID #{pid}"
     pid
   else
+    log "Performed running check: unicorn is not running"
     false
   end
 end

--- a/unicorn/templates/default/unicorn.service.erb
+++ b/unicorn/templates/default/unicorn.service.erb
@@ -1,20 +1,40 @@
 #!/usr/local/bin/ruby
+# unicorn restart script
+# copied from https://raw.githubusercontent.com/gethuman/chef/master/unicorn/templates/default/unicorn.service.erb
+# on May 27, 2021
 
 require 'etc'
 require 'digest/md5'
+require 'open3'
+require 'logger'
 
 ROOT_PATH="<%= @deploy[:deploy_to] %>"
 APP_NAME="<%= @application %>"
 PID_PATH="<%= @deploy[:deploy_to] %>/shared/pids/unicorn.pid"
+LOG_PATH="<%= @deploy[:deploy_to] %>/shared/log/unicorn.restart.log"
 
 def run_and_print_command(command)
-  puts command
-  system(command) || exit(1)
+  log command
+  result = system(command)
+  _stdout, stderr, status = Open3.capture3(command)
+
+  if status.success?
+    log "success"
+  else
+    log "failure, exitcode #{status.exitstatus}\n#{stderr}"
+    exit(1)
+  end
 end
 
 def run_and_ignore_exitcode_and_print_command(command)
-  puts command
-  system(command)
+  log command
+  _stdout, stderr, status = Open3.capture3(command)
+
+  if status.success?
+    log "success"
+  else
+    log "failure, exitcode #{status.exitstatus}\n#{stderr}"
+  end
 end
 
 def unicorn_running?
@@ -38,10 +58,10 @@ end
 
 def start_unicorn
   if File.exists?("#{ROOT_PATH}/current/Gemfile")
-    puts "OpsWorks: Gemfile detected - running Unicorn with bundle exec"
+    log "OpsWorks: Gemfile detected - running Unicorn with bundle exec"
     run_and_ignore_exitcode_and_print_command "cd #{ROOT_PATH}/current && /usr/local/bin/bundle exec unicorn_rails --env <%= @deploy[:rails_env] %> --daemonize -c #{ROOT_PATH}/shared/config/unicorn.conf"
   else
-    puts "OpsWorks: no Gemfile detected - running plain Unicorn"
+    log "OpsWorks: no Gemfile detected - running plain Unicorn"
     run_and_ignore_exitcode_and_print_command "cd #{ROOT_PATH}/current && unicorn_rails --env <%= @deploy[:rails_env] %> --daemonize -c #{ROOT_PATH}/shared/config/unicorn.conf"
   end
 end
@@ -52,7 +72,7 @@ def stop_unicorn
       `rm #{PID_PATH}`
     end
   else
-    puts "You can't stop unicorn, because it's not running"
+    log "You can't stop unicorn, because it's not running"
   end
 end
 
@@ -66,34 +86,45 @@ end
 
 def clean_restart
   if different_gemfile?
-    puts "Found a previous version with a different Gemfile: Doing a stop & start"
+    log "Found a previous version with a different Gemfile: Doing a stop & start"
     stop_unicorn if unicorn_running?
     start_unicorn
   else
-    puts "No previous version with a different Gemfile found. Assuming a quick restart without re-loading gems is save"
+    log "No previous version with a different Gemfile found. Assuming a quick restart without re-loading gems is save"
     restart_unicorn
   end
 end
 
 def status_unicorn
 	if pid = unicorn_running?
-		puts "Unicorn <%= @application %> running with PID #{pid}"
-		return true
+		log "Unicorn <%= @application %> running with PID #{pid}"
+		true
 	else
-		puts "Unicorn <%= @application %> not running"
-		return false
+		log "Unicorn <%= @application %> not running"
+		false
   end
 end
 
+def log(message)
+  puts message
+  logger.info message
+end
+
+def logger
+  return @logger if defined?(@logger)
+
+  @logger = Logger.new File.open(LOG_PATH, File::WRONLY | File::APPEND)
+end
+
 Process::Sys.setuid(uid = Etc.getpwnam("<%= @deploy[:user] %>").uid)
-puts "Set Unicorn process UID to #{uid}"
+log "Set Unicorn process UID to #{uid}"
 
 case ARGV[0]
 when "start"
-  puts "Starting Unicorn #{APP_NAME}"
+  log "Starting Unicorn #{APP_NAME}"
   start_unicorn
 when "stop"
-  puts "Stopping Unicorn #{APP_NAME}"
+  log "Stopping Unicorn #{APP_NAME}"
   stop_unicorn
 when "status"
   status_unicorn
@@ -102,7 +133,7 @@ when "restart"
 when "clean-restart"
   clean_restart
 else
-  puts "Usage: {start|stop|status|restart|clean-restart}"
+  log "Usage: {start|stop|status|restart|clean-restart}"
   exit 1
 end
 

--- a/unicorn/templates/default/unicorn.service.erb
+++ b/unicorn/templates/default/unicorn.service.erb
@@ -1,6 +1,7 @@
 #!/usr/local/bin/ruby
 # unicorn restart script
-# copied from https://raw.githubusercontent.com/gethuman/chef/master/unicorn/templates/default/unicorn.service.erb
+# template source: https://github.com/sdtechdev/frt-opsworks-cookbooks/blob/update_unicorn_script/unicorn/templates/default/unicorn.service.erb
+# original code: https://github.com/aws/opsworks-cookbooks/blob/release-chef-11.10/unicorn/templates/default/unicorn.service.erb
 # on May 27, 2021
 
 require 'etc'
@@ -113,7 +114,7 @@ end
 def logger
   return @logger if defined?(@logger)
 
-  @logger = Logger.new File.open(LOG_PATH, File::WRONLY | File::APPEND)
+  @logger = Logger.new File.open(LOG_PATH, File::WRONLY | File::APPEND | File::CREAT)
 end
 
 Process::Sys.setuid(uid = Etc.getpwnam("<%= @deploy[:user] %>").uid)


### PR DESCRIPTION
https://dekeo.atlassian.net/browse/DELTA-3048

in order to debug issues we need more logging

restart script template copied from https://github.com/aws/opsworks-cookbooks/tree/release-chef-11.10/unicorn/templates/default
file logging added (including exit codes and STDERR)

`stop; start` sequence creates noticeable downtime, so I'm not doing it now